### PR TITLE
HA-native cross-device sync, multi-floor zones, upload validation (fixes #8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist-server/
 .claude/
 CLAUDE.md
 server/certs/
+.local-model/

--- a/docs/ha-sync.md
+++ b/docs/ha-sync.md
@@ -1,0 +1,100 @@
+# HA-Native Sync & Multi-Zone Architecture
+
+Resolves [Issue #8](https://github.com/Kdcius/3Dash_webapp/issues/8): sync the
+config and 3D model across devices using only the user's Home Assistant —
+no external backend, no cloud, no GitHub tokens.
+
+## Storage design
+
+| Data | Where | Transport | Why |
+|---|---|---|---|
+| Config JSON | HA frontend user-data store (`.storage/frontend.user_data_<user>`) | WebSocket `frontend/set_user_data` / `get_user_data`, key `3dash_config` | Works on **every** HA install type (OS, Supervised, Container, Core), authenticated, per-user, included in HA backups, uses the WS connection the app already holds — no CORS issues |
+| 3D model (.glb) | `config/www/3dash/` on HA | HTTP GET `http(s)://<ha>:<port>/local/3dash/<name>.glb` | Served with the correct `model/gltf-binary` MIME and ETag support; cached in IndexedDB so startup is instant and works offline |
+
+Conflict resolution is last-writer-wins on `AppConfig.updatedAt` (stamped on
+every local mutation). On each successful HA connection the app reconciles:
+newer local → push; newer remote → apply + reload.
+
+### Why not the Media Source API?
+
+Verified against HA source and a live instance (2026.x):
+
+- `POST /api/media_source/local_source/upload` rejects any content type not
+  starting with `image/`, `video/`, `audio/` (`local_source.py`,
+  `async_upload_media`).
+- Even with a spoofed multipart content type the upload succeeds, but the
+  **serving** endpoint 404s for any file whose guessed MIME is outside
+  image/video/audio (`local_source.py`, mime check before serve). GLB
+  (`model/gltf-binary`) can therefore never be served back from `/media`.
+
+### Live test results (HA container install, host network)
+
+- `GET /local/3dash/config.json` → 200, `Content-Type: application/json`,
+  `Cache-Control: public, max-age=2678400`, ETag present, no auth required.
+- `GET /local/3dash/placeholder.glb` → 200, `Content-Type: model/gltf-binary`.
+- `frontend/set_user_data` / `get_user_data` → round-trips a 50 KB payload
+  without truncation; stored under the HA user tied to the token.
+- No `Access-Control-Allow-Origin` header on `/local/` responses.
+
+### Caveats
+
+1. **Caching** — `/local/` is served with a 31-day max-age. The app bypasses
+   this with `fetch(..., { cache: 'no-cache' })` + `If-None-Match`, so the
+   model refreshes as soon as the file on HA changes.
+2. **CORS** — when the webapp is served from a different origin than HA
+   (e.g. the add-on on port 8099, or a dev server), model fetches from
+   `/local/` need this in HA's `configuration.yaml`:
+
+   ```yaml
+   http:
+     cors_allowed_origins:
+       - http://homeassistant.local:8099   # wherever 3Dash is served from
+   ```
+
+   The config sync is unaffected (it rides the existing WebSocket).
+3. **Writing the model to HA** — there is no HA-native API for writing
+   arbitrary files to `config/www`. Users copy the file once via the Samba /
+   SSH / File editor add-on (models change rarely; the config, which changes
+   often, syncs automatically). The add-on could expose an upload endpoint in
+   a future iteration.
+
+## Using it
+
+1. Settings → Connection → **Sync: Auto** — config now syncs via HA.
+   *Push now / Pull now* trigger a manual sync.
+2. (Optional) copy your model to `config/www/3dash/model.glb` on HA and set
+   Settings → Connection → **Model Source: Home Assistant**. Devices fetch
+   and cache it automatically.
+
+## Zones / floors
+
+`AppConfig.zones` defines floors or areas (Ground Floor, Garage, Garden…):
+
+```jsonc
+{
+  "zones": [
+    {
+      "id": "ground",
+      "name": "Ground Floor",
+      "icon": "Home",                 // any lucide icon name
+      "meshFilter": {                  // show only meshes whose name starts with…
+        "mode": "include",            // or "exclude"
+        "prefixes": ["GF_", "Stairs"]
+      },
+      "cameraPose": {                  // optional saved view
+        "alpha": 4.71, "beta": 0.01, "radius": 14,
+        "target": { "x": 0, "y": 0, "z": 0 }
+      }
+    }
+  ],
+  "activeZoneId": "ground"
+}
+```
+
+Rendering strategy: **one model, per-zone visibility filters** on mesh-name
+prefixes — switching is instant (no reload, no extra VRAM) and shadows stay
+consistent. Zones are managed in Settings → Zones (name, icon, prefixes,
+filter mode, camera view capture) and switched with the floating button on
+the dashboard. The active zone persists in the config and therefore syncs
+across devices. `ZoneConfig.modelKey` is reserved for a future
+separate-model-per-zone mode.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Dashboard from './pages/Dashboard/Dashboard';
 
 const ConfigEditor = lazy(() => import('./pages/ConfigEditor/ConfigEditor'));
 const Onboarding = lazy(() => import('./pages/Onboarding/Onboarding'));
+const Connect = lazy(() => import('./pages/Connect/Connect'));
 
 function AppRoutes() {
   const location = useLocation();
@@ -19,8 +20,8 @@ function AppRoutes() {
   const onboardingDone = configExists && (getConfig().onboarding?.completed ?? false);
 
   // Redirect to onboarding if not completed and not already there
-  // (simulation mode bypasses onboarding)
-  if (!onboardingDone && !simulationMode && location.pathname !== '/onboarding') {
+  // (simulation mode and the one-tap /connect link bypass onboarding)
+  if (!onboardingDone && !simulationMode && location.pathname !== '/onboarding' && location.pathname !== '/connect') {
     return <Navigate to="/onboarding" replace />;
   }
 
@@ -29,6 +30,7 @@ function AppRoutes() {
       <Route path="/" element={<Dashboard />} />
       <Route path="/editor" element={<Suspense fallback={null}><ConfigEditor /></Suspense>} />
       <Route path="/onboarding" element={<Suspense fallback={null}><Onboarding /></Suspense>} />
+      <Route path="/connect" element={<Suspense fallback={null}><Connect /></Suspense>} />
     </Routes>
   );
 }

--- a/src/babylon/LightMeshFactory.ts
+++ b/src/babylon/LightMeshFactory.ts
@@ -109,6 +109,13 @@ export function createLightMesh(
     bulb.applyFog = false;
   }
 
+  // Hidden lights: bulb mesh invisible but still pickable (visibility ≠ isVisible).
+  // Only in live view (withPointLight) — the editor must keep the bulb visible for editing.
+  if (cfg.hidden && withPointLight) {
+    bulb.visibility = 0;
+    for (const eb of extraBulbs) eb.visibility = 0;
+  }
+
   let pointLight: PointLight | undefined;
   let shadowGen: ShadowGenerator | undefined;
   const stripLights: PointLight[] = [];

--- a/src/components/LightForm.tsx
+++ b/src/components/LightForm.tsx
@@ -102,6 +102,7 @@ const LightForm = forwardRef<LightFormHandle, Props>(function LightForm({
   const [warmth, setWarmth] = useState(3000);
   const [brightness, setBrightness] = useState(1);
   const [doubleTapEntityId, setDoubleTapEntityId] = useState('');
+  const [hidden, setHidden] = useState(false);
 
   // Multi-part state
   const [multiPart, setMultiPart] = useState(false);
@@ -152,6 +153,7 @@ const LightForm = forwardRef<LightFormHandle, Props>(function LightForm({
       setWarmth(editLight.warmth ?? 3000);
       setBrightness(editLight.brightness ?? 1);
       setDoubleTapEntityId(editLight.doubleTapEntityId ?? '');
+      setHidden(!!editLight.hidden);
       const hasParts = editLight.parts && editLight.parts.length > 0;
       setMultiPart(!!hasParts);
       setParts(hasParts ? editLight.parts!.map(partFromConfig) : []);
@@ -176,6 +178,7 @@ const LightForm = forwardRef<LightFormHandle, Props>(function LightForm({
       setWarmth(3000);
       setBrightness(1);
       setDoubleTapEntityId('');
+      setHidden(false);
       setMultiPart(false);
       setParts([]);
       setUseCustomHitbox(false);
@@ -245,6 +248,7 @@ const LightForm = forwardRef<LightFormHandle, Props>(function LightForm({
       brightness,
       hitbox,
       doubleTapEntityId: doubleTapEntityId.trim() || undefined,
+      hidden: hidden || undefined,
     };
 
     if (multiPart && parts.length > 0) {
@@ -261,7 +265,7 @@ const LightForm = forwardRef<LightFormHandle, Props>(function LightForm({
     }
 
     onSave(cfg);
-  }, [entityId, label, type, shape, diameter, width, height, depth, position, warmth, brightness, doubleTapEntityId, onSave, useCustomHitbox, multiPart, parts, hbShape, hbDiameter, hbWidth, hbHeight, hbDepth, hbPosX, hbPosY, hbPosZ]);
+  }, [entityId, label, type, shape, diameter, width, height, depth, position, warmth, brightness, doubleTapEntityId, hidden, onSave, useCustomHitbox, multiPart, parts, hbShape, hbDiameter, hbWidth, hbHeight, hbDepth, hbPosX, hbPosY, hbPosZ]);
 
   const handlePosChange = useCallback(
     (axis: 'x' | 'y' | 'z', value: number) => {
@@ -388,6 +392,16 @@ const LightForm = forwardRef<LightFormHandle, Props>(function LightForm({
       </AccordionSection>
 
       <AccordionSection title="Shape">
+        <div className="field-group">
+          <label className="field-label" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <input
+              type="checkbox"
+              checked={hidden}
+              onChange={(e) => setHidden(e.target.checked)}
+            />
+            Invisible (no bulb mesh — still clickable, still lights the room)
+          </label>
+        </div>
         <div className="field-group">
           <label className="field-label" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <input

--- a/src/components/SettingsModal.css
+++ b/src/components/SettingsModal.css
@@ -637,3 +637,20 @@
   border-width: 0 2px 2px 0;
   transform: rotate(45deg);
 }
+
+/* ── Zones editor ── */
+.settings-zones-hint {
+  font-size: 12px;
+  opacity: 0.65;
+  line-height: 1.5;
+  margin-bottom: 12px;
+}
+
+.settings-zone-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border, #1e293b);
+  margin-bottom: 8px;
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -4,12 +4,14 @@ import {
   Server, Palette, Box, MonitorCloud, Hand, Cog, Info,
   Lightbulb, LayoutTemplate, ChevronLeft, X,
   Monitor, Smartphone, Search, RotateCw, Move,
-  Github, HeartHandshake, Scale,
+  Github, HeartHandshake, Scale, Layers, Plus, Trash2, Camera,
 } from 'lucide-react';
 import { buildWsUrl, type HAConnectionStatus } from '../services/haWebSocket';
-import type { HASettings } from '../types';
-import { getConfig, resetConfig, updateConfig, exportBackup, importBackup } from '../services/configApi';
+import type { HASettings, ZoneCameraPose, ZoneConfig } from '../types';
+import { getConfig, resetConfig, updateConfig, exportBackup, importBackup, replaceConfig } from '../services/configApi';
 import { clearSettings, getSetting, getSettings, updateSettings } from '../services/settingsStore';
+import { pushConfigToHA, pullRemoteConfig } from '../services/haSync';
+import { showToast } from './Toast';
 import { useDemoMode } from '../contexts/DemoModeContext';
 import { useCameraControls, type CameraControlsFlags } from '../contexts/CameraControlsContext';
 import {
@@ -20,7 +22,7 @@ import {
 } from '../contexts/ThemeContext';
 import './SettingsModal.css';
 
-type Section = 'main' | 'connection' | 'appearance' | 'render' | 'environment' | 'controls' | 'system' | 'infos';
+type Section = 'main' | 'connection' | 'appearance' | 'render' | 'environment' | 'controls' | 'zones' | 'system' | 'infos';
 
 interface Props {
   open: boolean;
@@ -89,6 +91,12 @@ interface Props {
   haStatus: HAConnectionStatus;
   modelStatus: string;
   modelStatusColor?: string;
+
+  /* Zones */
+  /** Read the current camera pose (used as a zone's saved view). */
+  getCameraPose?: () => ZoneCameraPose | null;
+  /** Called after zones are saved so the dashboard can refresh its switcher. */
+  onZonesChanged?: (zones: ZoneConfig[]) => void;
 }
 
 const SECTIONS: { key: Section; label: string; icon: typeof Server }[] = [
@@ -97,6 +105,7 @@ const SECTIONS: { key: Section; label: string; icon: typeof Server }[] = [
   { key: 'render', label: 'Render', icon: Box },
   { key: 'environment', label: 'Environment', icon: MonitorCloud },
   { key: 'controls', label: 'Controls', icon: Hand },
+  { key: 'zones', label: 'Zones', icon: Layers },
   { key: 'system', label: 'System', icon: Cog },
   { key: 'infos', label: 'Infos', icon: Info },
 ];
@@ -140,6 +149,8 @@ export default function SettingsModal({
   haStatus,
   modelStatus,
   modelStatusColor,
+  getCameraPose,
+  onZonesChanged,
 }: Props) {
   const navigate = useNavigate();
   const { demoMode, setDemoMode } = useDemoMode();
@@ -156,6 +167,14 @@ export default function SettingsModal({
   const [haPort, setHaPort] = useState(haSettings.port);
   const [haToken, setHaToken] = useState(haSettings.token);
   const [haSaveStatus, setHaSaveStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
+  const [syncSettings, setSyncSettings] = useState(() => getSetting('sync'));
+  const [syncBusy, setSyncBusy] = useState(false);
+
+  /* Zones draft (saved to config only via the "Save zones" button) */
+  const [zonesDraft, setZonesDraft] = useState<ZoneConfig[]>(() => getConfig().zones ?? []);
+  const updateZone = useCallback((index: number, patch: Partial<ZoneConfig>) => {
+    setZonesDraft((zs) => zs.map((z, i) => (i === index ? { ...z, ...patch } : z)));
+  }, []);
   const [latitude, setLatitude] = useState('');
   const [longitude, setLongitude] = useState('');
   const importInputRef = useRef<HTMLInputElement>(null);
@@ -466,6 +485,99 @@ export default function SettingsModal({
                         : haSaveStatus === 'success' ? '\u2713 Connected'
                         : haSaveStatus === 'error' ? '\u2717 Failed'
                         : 'Save'}
+                    </button>
+                  </div>
+                </div>
+
+                {/* Cross-device sync (config stored in HA's frontend user-data) */}
+                <div className="settings-section">
+                  <div className="settings-section-label">Sync</div>
+                  <div className="settings-mode-toggle">
+                    <button
+                      className={`settings-mode-btn${syncSettings.autoSync ? ' active live' : ''}`}
+                      onClick={() => {
+                        updateSettings('sync', { autoSync: true });
+                        setSyncSettings((s) => ({ ...s, autoSync: true }));
+                      }}
+                    >
+                      Auto
+                    </button>
+                    <button
+                      className={`settings-mode-btn${!syncSettings.autoSync ? ' active demo' : ''}`}
+                      onClick={() => {
+                        updateSettings('sync', { autoSync: false });
+                        setSyncSettings((s) => ({ ...s, autoSync: false }));
+                      }}
+                    >
+                      Off
+                    </button>
+                  </div>
+                  <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+                    <button
+                      className="settings-action-btn"
+                      disabled={syncBusy}
+                      onClick={async () => {
+                        setSyncBusy(true);
+                        try {
+                          await pushConfigToHA(getConfig());
+                          showToast('success', 'Config pushed to Home Assistant');
+                        } catch (e) {
+                          showToast('error', `Push failed: ${e instanceof Error ? e.message : e}`);
+                        } finally {
+                          setSyncBusy(false);
+                        }
+                      }}
+                    >
+                      Push now
+                    </button>
+                    <button
+                      className="settings-action-btn"
+                      disabled={syncBusy}
+                      onClick={async () => {
+                        setSyncBusy(true);
+                        try {
+                          const remote = await pullRemoteConfig();
+                          if (!remote) {
+                            showToast('info', 'No config stored on Home Assistant yet');
+                          } else {
+                            replaceConfig(remote.config);
+                            showToast('success', 'Config pulled \u2014 reloading\u2026');
+                            setTimeout(() => window.location.reload(), 800);
+                          }
+                        } catch (e) {
+                          showToast('error', `Pull failed: ${e instanceof Error ? e.message : e}`);
+                        } finally {
+                          setSyncBusy(false);
+                        }
+                      }}
+                    >
+                      Pull now
+                    </button>
+                  </div>
+                </div>
+
+                {/* Model source: this device's storage vs. HA config/www/3dash */}
+                <div className="settings-section">
+                  <div className="settings-section-label">Model Source</div>
+                  <div className="settings-mode-toggle">
+                    <button
+                      className={`settings-mode-btn${syncSettings.modelSource === 'device' ? ' active live' : ''}`}
+                      onClick={() => {
+                        updateSettings('sync', { modelSource: 'device' });
+                        setSyncSettings((s) => ({ ...s, modelSource: 'device' }));
+                      }}
+                    >
+                      This device
+                    </button>
+                    <button
+                      className={`settings-mode-btn${syncSettings.modelSource === 'ha' ? ' active live' : ''}`}
+                      onClick={() => {
+                        updateSettings('sync', { modelSource: 'ha' });
+                        setSyncSettings((s) => ({ ...s, modelSource: 'ha' }));
+                        showToast('info', 'Place your model at config/www/3dash/model.glb on HA');
+                      }}
+                    >
+                      Home Assistant
                     </button>
                   </div>
                 </div>
@@ -980,6 +1092,120 @@ export default function SettingsModal({
                 <div className="settings-infos-footer">
                   <HeartHandshake size={16} strokeWidth={1.5} />
                   <span>Built with love in Montpellier</span>
+                </div>
+              </div>
+            )}
+
+            {/* Zones / floors */}
+            {(section === 'zones' || (animating && prevSection === 'zones')) && (
+              <div className="settings-page">
+                <div className="settings-section">
+                  <div className="settings-section-label">Floors & Areas</div>
+                  <div className="settings-zones-hint">
+                    Zones show or hide parts of the model by mesh-name prefix
+                    (e.g. all ground-floor meshes named "GF_…"). Switch zones
+                    with the floating button on the dashboard.
+                  </div>
+                  {zonesDraft.map((z, i) => (
+                    <div key={z.id} className="settings-zone-row">
+                      <div className="settings-ha-row">
+                        <div className="settings-ha-field" style={{ flex: 2 }}>
+                          <label className="settings-ha-label">Name</label>
+                          <input
+                            className="settings-ha-input"
+                            type="text"
+                            placeholder="Ground Floor"
+                            value={z.name}
+                            onChange={(e) => updateZone(i, { name: e.target.value })}
+                          />
+                        </div>
+                        <div className="settings-ha-field" style={{ flex: 1 }}>
+                          <label className="settings-ha-label">Icon</label>
+                          <input
+                            className="settings-ha-input"
+                            type="text"
+                            placeholder="Home"
+                            value={z.icon ?? ''}
+                            onChange={(e) => updateZone(i, { icon: e.target.value || undefined })}
+                          />
+                        </div>
+                      </div>
+                      <div className="settings-ha-row">
+                        <div className="settings-ha-field" style={{ flex: 2 }}>
+                          <label className="settings-ha-label">Mesh prefixes (comma-separated)</label>
+                          <input
+                            className="settings-ha-input"
+                            type="text"
+                            placeholder="GF_, Stairs"
+                            value={z.meshFilter?.prefixes.join(', ') ?? ''}
+                            onChange={(e) => {
+                              const prefixes = e.target.value.split(',').map((p) => p.trim()).filter(Boolean);
+                              updateZone(i, {
+                                meshFilter: prefixes.length
+                                  ? { mode: z.meshFilter?.mode ?? 'include', prefixes }
+                                  : undefined,
+                              });
+                            }}
+                          />
+                        </div>
+                        <div className="settings-ha-field" style={{ flex: 1 }}>
+                          <label className="settings-ha-label">Filter</label>
+                          <button
+                            className="settings-action-btn"
+                            onClick={() => updateZone(i, {
+                              meshFilter: z.meshFilter
+                                ? { ...z.meshFilter, mode: z.meshFilter.mode === 'include' ? 'exclude' : 'include' }
+                                : undefined,
+                            })}
+                          >
+                            {z.meshFilter?.mode === 'exclude' ? 'Hide listed' : 'Show listed'}
+                          </button>
+                        </div>
+                      </div>
+                      <div style={{ display: 'flex', gap: 8 }}>
+                        <button
+                          className="settings-action-btn"
+                          title="Save the current camera position as this zone's view"
+                          onClick={() => {
+                            const pose = getCameraPose?.() ?? null;
+                            updateZone(i, { cameraPose: pose });
+                            if (pose) showToast('success', `Camera view saved for ${z.name || 'zone'}`);
+                          }}
+                        >
+                          <Camera size={14} /> {z.cameraPose ? 'Update view' : 'Set view'}
+                        </button>
+                        <button
+                          className="settings-action-btn"
+                          onClick={() => setZonesDraft((zs) => zs.filter((_, j) => j !== i))}
+                        >
+                          <Trash2 size={14} /> Remove
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                  <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+                    <button
+                      className="settings-action-btn"
+                      onClick={() => setZonesDraft((zs) => [...zs, {
+                        id: `zone-${Date.now().toString(36)}`,
+                        name: '',
+                        meshFilter: { mode: 'include', prefixes: [] },
+                      }])}
+                    >
+                      <Plus size={14} /> Add zone
+                    </button>
+                    <button
+                      className="settings-action-btn"
+                      onClick={() => {
+                        const cleaned = zonesDraft.filter((z) => z.name.trim());
+                        updateConfig({ zones: cleaned });
+                        onZonesChanged?.(cleaned);
+                        showToast('success', 'Zones saved');
+                      }}
+                    >
+                      Save zones
+                    </button>
+                  </div>
                 </div>
               </div>
             )}

--- a/src/components/Toast.css
+++ b/src/components/Toast.css
@@ -1,0 +1,42 @@
+.toast-host {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  z-index: 300;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: var(--radius, 8px);
+  background: var(--panel-bg, rgba(15, 23, 42, 0.92));
+  color: var(--text, #e2e8f0);
+  border: 1px solid var(--border, #1e293b);
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  animation: toast-in 0.25s ease-out;
+  max-width: min(90vw, 480px);
+}
+
+.toast-icon { flex-shrink: 0; }
+
+.toast-success .toast-icon { color: var(--green, #4ade80); }
+.toast-error .toast-icon { color: var(--red, #f87171); }
+.toast-warning .toast-icon { color: var(--orange, #fb923c); }
+.toast-info .toast-icon { color: var(--blue, #60a5fa); }
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { CheckCircle2, AlertTriangle, Info, XCircle } from 'lucide-react';
+import './Toast.css';
+
+export type ToastKind = 'success' | 'error' | 'warning' | 'info';
+
+export interface ToastItem {
+  id: number;
+  kind: ToastKind;
+  message: string;
+}
+
+type Listener = (toasts: ToastItem[]) => void;
+
+let nextId = 1;
+let toasts: ToastItem[] = [];
+const listeners = new Set<Listener>();
+
+function emit(): void {
+  for (const l of listeners) l([...toasts]);
+}
+
+/** Show a toast from anywhere (no React context needed). */
+export function showToast(kind: ToastKind, message: string, durationMs = 4000): void {
+  const item: ToastItem = { id: nextId++, kind, message };
+  toasts = [...toasts, item];
+  emit();
+  setTimeout(() => {
+    toasts = toasts.filter((t) => t.id !== item.id);
+    emit();
+  }, durationMs);
+}
+
+const ICONS: Record<ToastKind, typeof Info> = {
+  success: CheckCircle2,
+  error: XCircle,
+  warning: AlertTriangle,
+  info: Info,
+};
+
+/** Mount once (e.g. in Dashboard / Onboarding) to render active toasts. */
+export default function ToastHost() {
+  const [items, setItems] = useState<ToastItem[]>([]);
+
+  useEffect(() => {
+    const l: Listener = setItems;
+    listeners.add(l);
+    return () => { listeners.delete(l); };
+  }, []);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="toast-host" role="status" aria-live="polite">
+      {items.map((t) => {
+        const Icon = ICONS[t.kind];
+        return (
+          <div key={t.id} className={`toast toast-${t.kind}`}>
+            <Icon size={16} className="toast-icon" />
+            <span>{t.message}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ZoneSwitcher.css
+++ b/src/components/ZoneSwitcher.css
@@ -1,0 +1,83 @@
+.zone-switcher {
+  position: absolute;
+  bottom: 84px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  z-index: 40;
+  pointer-events: auto;
+}
+
+.zone-fab {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px;
+  min-width: 44px;
+  min-height: 44px;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid var(--border, #1e293b);
+  background: var(--panel-bg, rgba(15, 23, 42, 0.85));
+  color: var(--text, #e2e8f0);
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
+  transition: border-color 0.15s, transform 0.15s;
+}
+
+.zone-fab:hover {
+  border-color: var(--green, #4ade80);
+  transform: translateY(-1px);
+}
+
+.zone-fab-label {
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding-right: 4px;
+}
+
+.zone-switcher-menu {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  animation: zone-menu-in 0.18s ease-out;
+}
+
+.zone-pill {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border, #1e293b);
+  background: var(--panel-bg, rgba(15, 23, 42, 0.85));
+  color: var(--text, #e2e8f0);
+  font-size: 12.5px;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.zone-pill:hover { border-color: var(--green, #4ade80); }
+
+.zone-pill.active {
+  border-color: var(--green, #4ade80);
+  color: var(--green, #4ade80);
+}
+
+@keyframes zone-menu-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 768px) {
+  .zone-switcher { bottom: 96px; right: 12px; }
+}

--- a/src/components/ZoneSwitcher.tsx
+++ b/src/components/ZoneSwitcher.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { Layers } from 'lucide-react';
+import LucideIcon from './SidePanel/cards/LucideIcon';
+import type { ZoneConfig } from '../types';
+import './ZoneSwitcher.css';
+
+interface Props {
+  zones: ZoneConfig[];
+  activeZoneId: string | null;
+  /** null = show everything (no zone filter). */
+  onSelect: (zoneId: string | null) => void;
+}
+
+/**
+ * Floating action button for switching between floors / areas
+ * (e.g. Outside, Ground Floor, First Floor, Garage, Garden).
+ * Collapsed: a single layers button. Expanded: one pill per zone.
+ */
+export default function ZoneSwitcher({ zones, activeZoneId, onSelect }: Props) {
+  const [open, setOpen] = useState(false);
+
+  if (zones.length === 0) return null;
+
+  const active = zones.find((z) => z.id === activeZoneId) ?? null;
+
+  const select = (id: string | null) => {
+    onSelect(id);
+    setOpen(false);
+  };
+
+  return (
+    <div className={`zone-switcher${open ? ' open' : ''}`}>
+      {open && (
+        <div className="zone-switcher-menu" role="menu">
+          <button
+            role="menuitem"
+            className={`zone-pill${!active ? ' active' : ''}`}
+            onClick={() => select(null)}
+          >
+            <Layers size={15} />
+            <span>All</span>
+          </button>
+          {zones.map((z) => (
+            <button
+              key={z.id}
+              role="menuitem"
+              className={`zone-pill${active?.id === z.id ? ' active' : ''}`}
+              onClick={() => select(z.id)}
+            >
+              {z.icon ? <LucideIcon name={z.icon} size={15} /> : <Layers size={15} />}
+              <span>{z.name}</span>
+            </button>
+          ))}
+        </div>
+      )}
+      <button
+        className="zone-fab"
+        aria-label="Switch zone"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {active?.icon ? <LucideIcon name={active.icon} size={20} /> : <Layers size={20} />}
+        {active && <span className="zone-fab-label">{active.name}</span>}
+      </button>
+    </div>
+  );
+}

--- a/src/data/simulationData.ts
+++ b/src/data/simulationData.ts
@@ -136,6 +136,21 @@ export const SIMULATION_CONFIG: AppConfig = {
     },
   ],
   onboarding: { completed: true },
+  // Demo zones: camera-pose presets (no mesh filter on the single demo model)
+  zones: [
+    {
+      id: 'outside',
+      name: 'Outside',
+      icon: 'Trees',
+      cameraPose: { alpha: 4.0, beta: 1.2, radius: 26, target: { x: -4.5, y: 0, z: -5 } },
+    },
+    {
+      id: 'inside',
+      name: 'Inside',
+      icon: 'Home',
+      cameraPose: { alpha: 4.712, beta: 0.01, radius: 14, target: { x: -4.5, y: 0, z: -5 } },
+    },
+  ],
   shadowWalls: [
     {
       id: '5a31101b-e20c-4c78-be48-83d1fe5e0fd7',
@@ -346,6 +361,11 @@ export const SIMULATION_SETTINGS: AppSettings = {
   },
   misc: {
     panelRatio: null,
+  },
+  sync: {
+    autoSync: false,
+    modelSource: 'device',
+    modelName: 'model',
   },
 };
 

--- a/src/pages/ConfigEditor/ConfigEditor.tsx
+++ b/src/pages/ConfigEditor/ConfigEditor.tsx
@@ -31,6 +31,7 @@ import {
   type DisplayMeshMap,
 } from '../../babylon/DisplayMeshFactory';
 import { getConfig, updateConfig, getModelBlob } from '../../services/configApi';
+import { fetchModelFromHA } from '../../services/haSync';
 import { getSetting } from '../../services/settingsStore';
 import { getEntityCache, setEntityCache } from '../../services/entityCache';
 import { HAConnection } from '../../services/haWebSocket';
@@ -481,8 +482,17 @@ export default function ConfigEditor() {
         setTubes(config.tubes || []);
         tubesRef.current = config.tubes || [];
 
-        // Load model from IndexedDB
-        const modelBlob = await getModelBlob();
+        // Load model from the same source the dashboard uses (HA or device)
+        let modelBlob: Blob | null = null;
+        const syncSettings = getSetting('sync');
+        if (syncSettings.modelSource === 'ha') {
+          modelBlob = await fetchModelFromHA(syncSettings.modelName);
+          if (!modelBlob) {
+            modelBlob = await getModelBlob();
+          }
+        } else {
+          modelBlob = await getModelBlob();
+        }
         if (!modelBlob) {
           navigate('/onboarding');
           return;

--- a/src/pages/Connect/Connect.tsx
+++ b/src/pages/Connect/Connect.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { testHA } from '../Onboarding/steps/HASetupStep';
 import { updateSettings } from '../../services/settingsStore';
-import { updateConfig, getConfig } from '../../services/configApi';
+import { updateConfig, getConfig, replaceConfig } from '../../services/configApi';
 
 /**
  * One-tap device setup: /#/connect?ha_url=...&ha_port=...&ha_token=...
@@ -45,6 +45,9 @@ export default function Connect() {
         onboarding: { completed: true },
         location: cfg.location ?? { latitude: 51.0, longitude: 10.0 },
       });
+      // Zero the timestamp: this device starts empty, so any remote config
+      // must win the first sync instead of being clobbered by this stub.
+      replaceConfig({ ...getConfig(), updatedAt: 0 });
 
       navigate('/', { replace: true });
     })();

--- a/src/pages/Connect/Connect.tsx
+++ b/src/pages/Connect/Connect.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { testHA } from '../Onboarding/steps/HASetupStep';
+import { updateSettings } from '../../services/settingsStore';
+import { updateConfig, getConfig } from '../../services/configApi';
+
+/**
+ * One-tap device setup: /#/connect?ha_url=...&ha_port=...&ha_token=...
+ *
+ * Lets a single generated link configure a new device (phone, tablet) without
+ * retyping the HA URL/token by hand. Tests the connection, saves it, marks
+ * onboarding complete, and enables cross-device sync — then redirects home.
+ */
+export default function Connect() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [status, setStatus] = useState<'connecting' | 'error'>('connecting');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const url = params.get('ha_url');
+    const port = parseInt(params.get('ha_port') || '8123', 10);
+    const token = params.get('ha_token');
+
+    if (!url || !token) {
+      setStatus('error');
+      setErrorMsg('Missing ha_url or ha_token in link');
+      return;
+    }
+
+    (async () => {
+      const result = await testHA(url, port, token);
+      if (!result.success) {
+        setStatus('error');
+        setErrorMsg(result.error || 'Connection failed');
+        return;
+      }
+
+      updateSettings('connection', { haSettings: { url, port, token } });
+      updateSettings('sync', { autoSync: true, modelSource: 'ha', modelName: 'model' });
+
+      const cfg = getConfig();
+      updateConfig({
+        onboarding: { completed: true },
+        location: cfg.location ?? { latitude: 51.0, longitude: 10.0 },
+      });
+
+      navigate('/', { replace: true });
+    })();
+  }, [location.search, navigate]);
+
+  return (
+    <div className="onboarding-step" style={{ textAlign: 'center', paddingTop: '20vh' }}>
+      <h1>3Dash</h1>
+      {status === 'connecting' && <h2>Connecting to Home Assistant…</h2>}
+      {status === 'error' && (
+        <>
+          <h2>Couldn't connect</h2>
+          <p>{errorMsg}</p>
+          <button className="onboarding-btn primary" onClick={() => navigate('/onboarding', { replace: true })}>
+            Set up manually
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -19,7 +19,10 @@ import {
   setDisplayAnimation,
   type DisplayMeshMap,
 } from '../../babylon/DisplayMeshFactory';
-import { getConfig, updateConfig, getModelBlob } from '../../services/configApi';
+import { getConfig, updateConfig, getModelBlob, replaceConfig, setConfigChangedHook } from '../../services/configApi';
+import { schedulePush, syncOnConnect, fetchModelFromHA } from '../../services/haSync';
+import ToastHost, { showToast } from '../../components/Toast';
+import ZoneSwitcher from '../../components/ZoneSwitcher';
 import { getEntityCache, setEntityCache } from '../../services/entityCache';
 import type { HAEntityOption } from '../../components/EntityPicker';
 import { getSetting, updateSettings, type HomeViewPose } from '../../services/settingsStore';
@@ -46,7 +49,7 @@ import GuidedTour from '../../components/GuidedTour/GuidedTour';
 import { dashboardTourSteps } from '../../components/GuidedTour/tourSteps';
 import CardPropertiesPanel from '../../components/SidePanel/CardPropertiesPanel';
 import { SIMULATION_CONFIG, SIMULATION_MODEL_URL } from '../../data/simulationData';
-import type { AppConfig, DisplayConfig, LightConfig, RemoteButton, HAState, CardLayout, SidePanelCard } from '../../types';
+import type { AppConfig, DisplayConfig, LightConfig, RemoteButton, HAState, CardLayout, SidePanelCard, ZoneConfig } from '../../types';
 import './Dashboard.css';
 
 const LONG_PRESS_MS = 500;
@@ -118,6 +121,54 @@ export default function Dashboard() {
     updateSettings('misc', { panelRatio: ratio });
   }, []);
   const [settingsOpen, setSettingsOpen] = useState(false);
+
+  /* ── Zones / floors ── */
+  const [zones, setZones] = useState<ZoneConfig[]>([]);
+  const [activeZoneId, setActiveZoneId] = useState<string | null>(null);
+
+  /** Show/hide model meshes according to a zone's mesh-name filter. */
+  const applyZoneVisibility = useCallback((zone: ZoneConfig | null) => {
+    const meshes = modelMeshesRef.current;
+    if (!meshes.length) return;
+    const filter = zone?.meshFilter;
+    for (const mesh of meshes) {
+      if (!filter || filter.prefixes.length === 0) {
+        mesh.setEnabled(true);
+        continue;
+      }
+      const name = mesh.name.toLowerCase();
+      const matches = filter.prefixes.some((p) => name.startsWith(p.toLowerCase()));
+      mesh.setEnabled(filter.mode === 'include' ? matches : !matches);
+    }
+  }, []);
+
+  const handleZoneSelect = useCallback((zoneId: string | null) => {
+    const config = configRef.current;
+    if (!config) return;
+    const zone = config.zones?.find((z) => z.id === zoneId) ?? null;
+    setActiveZoneId(zone?.id ?? null);
+    applyZoneVisibility(zone);
+
+    // Fly to the zone's camera pose when one is defined
+    const camera = sceneCtxRef.current?.camera;
+    if (camera && zone?.cameraPose) {
+      const p = zone.cameraPose;
+      camera.target = new Vector3(p.target.x, p.target.y, p.target.z);
+      camera.alpha = p.alpha;
+      camera.beta = p.beta;
+      camera.radius = p.radius;
+    }
+    if (!simulationMode) updateConfig({ activeZoneId: zone?.id ?? undefined });
+  }, [applyZoneVisibility, simulationMode]);
+
+  /* ── HA config sync (Issue #8): push local edits, pull newer remote ── */
+  useEffect(() => {
+    if (simulationMode || demoMode) return;
+    setConfigChangedHook((cfg) => schedulePush(() => cfg));
+    return () => setConfigChangedHook(null);
+  }, [simulationMode, demoMode]);
+
+  const syncAttemptedRef = useRef(false);
   const [cardStates, setCardStates] = useState<Record<string, HAState>>({});
   const [gridEditMode, setGridEditMode] = useState(false);
   const [cardPanelOpen, setCardPanelOpen] = useState(false);
@@ -701,7 +752,18 @@ export default function Dashboard() {
           return;
         }
       } else {
-        modelBlob = await getModelBlob();
+        const syncSettings = getSetting('sync');
+        if (syncSettings.modelSource === 'ha') {
+          // Model hosted in HA's config/www/3dash — ETag-cached in IndexedDB
+          modelBlob = await fetchModelFromHA(syncSettings.modelName);
+          if (!modelBlob) {
+            // Fall back to the locally uploaded model
+            modelBlob = await getModelBlob();
+            if (modelBlob) showToast('warning', 'Could not reach HA model — using local copy');
+          }
+        } else {
+          modelBlob = await getModelBlob();
+        }
       }
       if (!modelBlob) {
         navigate('/onboarding');
@@ -746,6 +808,17 @@ export default function Dashboard() {
         modelMeshesRef.current = result.meshes.filter(
           (m) => m.getTotalVertices?.() > 0,
         );
+
+        // Restore zones + last active zone (visibility filter) from config
+        {
+          const cfgZones = configRef.current?.zones ?? [];
+          setZones(cfgZones);
+          const savedZone = cfgZones.find((z) => z.id === configRef.current?.activeZoneId) ?? null;
+          if (savedZone) {
+            setActiveZoneId(savedZone.id);
+            applyZoneVisibility(savedZone);
+          }
+        }
 
         // Apply persisted edge width to model meshes (ModelLoader defaults to 3)
         {
@@ -1025,7 +1098,25 @@ export default function Dashboard() {
     }
 
     const callbacks = {
-      onStatusChanged: (status: HAConnectionStatus) => setHaStatus(status),
+      onStatusChanged: (status: HAConnectionStatus) => {
+        setHaStatus(status);
+        // First successful connection → reconcile config with HA user-data store
+        if (status === 'connected' && !simulationMode && !demoMode && !syncAttemptedRef.current) {
+          syncAttemptedRef.current = true;
+          const local = configRef.current;
+          if (local) {
+            syncOnConnect(local).then((res) => {
+              if (res.action === 'pulled' && res.remoteConfig) {
+                replaceConfig(res.remoteConfig);
+                showToast('info', 'Newer config found on Home Assistant — applying…');
+                setTimeout(() => window.location.reload(), 1200);
+              } else if (res.action === 'pushed') {
+                showToast('success', 'Config synced to Home Assistant');
+              }
+            }).catch((e) => console.warn('[haSync] initial sync failed:', e));
+          }
+        }
+      },
       onStateChanged: (entityId: string, state: HAState) => {
         stopPendingFeedback(entityId);
         if (meshMapRef.current[entityId]) applyLightState(entityId, state);
@@ -1616,6 +1707,13 @@ export default function Dashboard() {
           cloudCoverFactor={cloudCoverFactor}
         />
 
+        <ZoneSwitcher
+          zones={zones}
+          activeZoneId={activeZoneId}
+          onSelect={handleZoneSelect}
+        />
+        <ToastHost />
+
         <DebugPanel
           open={debugOpen}
           onClose={() => setDebugOpen(false)}
@@ -1713,6 +1811,24 @@ export default function Dashboard() {
           haStatus={haStatus}
           modelStatus={modelStatus}
           modelStatusColor={modelStatusColor}
+          getCameraPose={() => {
+            const cam = sceneCtxRef.current?.camera;
+            if (!cam) return null;
+            return {
+              alpha: cam.alpha,
+              beta: cam.beta,
+              radius: cam.radius,
+              target: { x: cam.target.x, y: cam.target.y, z: cam.target.z },
+            };
+          }}
+          onZonesChanged={(newZones) => {
+            if (configRef.current) configRef.current = { ...configRef.current, zones: newZones };
+            setZones(newZones);
+            // Drop the active zone if it was removed
+            if (activeZoneId && !newZones.some((z) => z.id === activeZoneId)) {
+              handleZoneSelect(null);
+            }
+          }}
         />
 
         {homeViewSetting && (

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -19,7 +19,7 @@ import {
   setDisplayAnimation,
   type DisplayMeshMap,
 } from '../../babylon/DisplayMeshFactory';
-import { getConfig, updateConfig, getModelBlob, replaceConfig, setConfigChangedHook } from '../../services/configApi';
+import { getConfig, updateConfig, getModelBlob, replaceConfig, setConfigChangedHook, hasConfig } from '../../services/configApi';
 import { schedulePush, syncOnConnect, fetchModelFromHA } from '../../services/haSync';
 import ToastHost, { showToast } from '../../components/Toast';
 import ZoneSwitcher from '../../components/ZoneSwitcher';
@@ -1677,7 +1677,13 @@ export default function Dashboard() {
         onCardDelete={handleCardDelete}
         onExitSimulation={simulationMode ? () => {
           setSimulationMode(false);
-          navigate('/onboarding');
+          // Configured devices return to their live dashboard; a full reload
+          // clears all in-memory simulation state (HA adapter, model, config).
+          if (hasConfig() && (getConfig().onboarding?.completed ?? false)) {
+            window.location.reload();
+          } else {
+            navigate('/onboarding');
+          }
         } : undefined}
       />
       {cardPanelOpen && (

--- a/src/pages/Onboarding/Onboarding.css
+++ b/src/pages/Onboarding/Onboarding.css
@@ -522,3 +522,10 @@
     height: 28px;
   }
 }
+
+.onboarding-welcome-simulation-hint {
+  font-size: 12px;
+  opacity: 0.55;
+  text-align: center;
+  margin: -4px 0 4px;
+}

--- a/src/pages/Onboarding/Onboarding.tsx
+++ b/src/pages/Onboarding/Onboarding.tsx
@@ -12,6 +12,7 @@ import HASetupStep, { testHA } from './steps/HASetupStep';
 import ModelUploadStep from './steps/ModelUploadStep';
 import LocationStep from './steps/LocationStep';
 import CompletionStep from './steps/CompletionStep';
+import ToastHost from '../../components/Toast';
 import './Onboarding.css';
 
 // Steps: Welcome(0) ImportReport(1) HA(2) Model(3) Location(4) Done(5)
@@ -207,6 +208,7 @@ export default function Onboarding() {
 
   return (
     <div className="onboarding">
+      <ToastHost />
       <button
         className="onboarding-theme-toggle"
         onClick={() => setTheme(resolved === 'dark' ? 'light' : 'dark')}

--- a/src/pages/Onboarding/steps/ModelUploadStep.tsx
+++ b/src/pages/Onboarding/steps/ModelUploadStep.tsx
@@ -1,25 +1,55 @@
 import { useState, useRef, useCallback } from 'react';
 import { uploadModel } from '../../../services/configApi';
+import { validateGlb } from '../../../utils/validateGlb';
+import { showToast } from '../../../components/Toast';
 
 interface Props {
   onComplete: () => void;
 }
 
+const MAX_RECOMMENDED_MB = 50;
+
 export default function ModelUploadStep({ onComplete }: Props) {
   const [file, setFile] = useState<File | null>(null);
+  const [modelInfo, setModelInfo] = useState('');
   const [dragOver, setDragOver] = useState(false);
+  const [validating, setValidating] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleFile = useCallback((f: File) => {
-    if (!f.name.endsWith('.glb')) {
-      setError('Only .glb files are supported');
+  const handleFile = useCallback(async (f: File) => {
+    setError('');
+    setModelInfo('');
+    setFile(null);
+
+    if (!f.name.toLowerCase().endsWith('.glb')) {
+      setError('Only .glb files are supported (binary glTF). If you have a .gltf, re-export as .glb.');
       return;
     }
+
+    // Structural validation before accepting the file
+    setValidating(true);
+    const result = await validateGlb(f);
+    setValidating(false);
+
+    if (!result.valid) {
+      setError(result.error ?? 'The file is not a valid 3D model.');
+      showToast('error', 'Model validation failed');
+      return;
+    }
+
     setFile(f);
-    setError('');
+    const parts = [`${result.meshCount} mesh${result.meshCount === 1 ? '' : 'es'}`];
+    if (result.generator) parts.push(`exported from ${result.generator.split(' ')[0]}`);
+    setModelInfo(parts.join(' · '));
+
+    if (f.size > MAX_RECOMMENDED_MB * 1024 * 1024) {
+      showToast('warning', `Model is ${(f.size / 1048576).toFixed(0)} MB — may be slow on mobile devices`);
+    } else {
+      showToast('success', 'Valid 3D model');
+    }
   }, []);
 
   const handleDrop = useCallback((e: React.DragEvent) => {
@@ -35,7 +65,7 @@ export default function ModelUploadStep({ onComplete }: Props) {
     setProgress(0);
     setError('');
 
-    // Simulate progress since fetch doesn't give upload progress easily
+    // Simulate progress since IndexedDB writes don't report progress
     const progressInterval = setInterval(() => {
       setProgress((p) => Math.min(p + 15, 90));
     }, 200);
@@ -44,13 +74,15 @@ export default function ModelUploadStep({ onComplete }: Props) {
       await uploadModel(file);
       clearInterval(progressInterval);
       setProgress(100);
+      showToast('success', 'Model saved');
       setTimeout(() => {
         setUploading(false);
         onComplete();
       }, 400);
     } catch {
       clearInterval(progressInterval);
-      setError('Upload failed. Please try again.');
+      setError('Saving the model failed. Please try again.');
+      showToast('error', 'Saving the model failed');
       setUploading(false);
       setProgress(0);
     }
@@ -87,13 +119,13 @@ export default function ModelUploadStep({ onComplete }: Props) {
         onDrop={handleDrop}
         onClick={() => inputRef.current?.click()}
       >
-        <div className="onboarding-upload-icon">{file ? '\u2713' : '\u21A5'}</div>
+        <div className="onboarding-upload-icon">{file ? '✓' : '↥'}</div>
         <div className="onboarding-upload-text">
-          {file ? '' : 'Drop your .glb file here or click to browse'}
+          {validating ? 'Validating model…' : file ? '' : 'Drop your .glb file here or click to browse'}
         </div>
         {file && (
           <div className="onboarding-upload-file">
-            {file.name} ({formatSize(file.size)})
+            {file.name} ({formatSize(file.size)}){modelInfo ? ` — ${modelInfo}` : ''}
           </div>
         )}
         {uploading && (
@@ -114,13 +146,14 @@ export default function ModelUploadStep({ onComplete }: Props) {
           <li>Use real-world scale in meters</li>
           <li>Keep polygon count reasonable for performance</li>
           <li>The model will be auto-scaled if units are in millimeters</li>
+          <li>For cross-device use, also copy the file to Home Assistant at <code>config/www/3dash/model.glb</code></li>
         </ul>
       </div>
 
       <button
         className="onboarding-btn primary"
         onClick={handleUpload}
-        disabled={!file || uploading}
+        disabled={!file || uploading || validating}
       >
         {uploading ? 'Uploading...' : 'Upload & Continue'}
       </button>

--- a/src/pages/Onboarding/steps/WelcomeStep.tsx
+++ b/src/pages/Onboarding/steps/WelcomeStep.tsx
@@ -37,6 +37,9 @@ export default function WelcomeStep({ onConnect, onSimulation, onImport }: Props
         <button className="onboarding-btn simulation" onClick={onSimulation} disabled={importing}>
           Try Simulation
         </button>
+        <p className="onboarding-welcome-simulation-hint">
+          Preview only — a sample apartment with fake data, not your real setup
+        </p>
         <button
           className="onboarding-btn import"
           onClick={() => fileRef.current?.click()}

--- a/src/services/configApi.ts
+++ b/src/services/configApi.ts
@@ -44,7 +44,9 @@ export function getConfig(): AppConfig {
   const raw = localStorage.getItem(CONFIG_KEY);
   if (!raw) return { ...DEFAULT_CONFIG };
   try {
-    return JSON.parse(raw) as AppConfig;
+    // Merge over defaults so required fields (lights, location) always exist,
+    // even for configs imported from backups or pulled from HA sync.
+    return { ...DEFAULT_CONFIG, ...(JSON.parse(raw) as Partial<AppConfig>) } as AppConfig;
   } catch {
     return { ...DEFAULT_CONFIG };
   }

--- a/src/services/configApi.ts
+++ b/src/services/configApi.ts
@@ -1,10 +1,20 @@
 import JSZip from 'jszip';
-import type { AppConfig, DisplayConfig, LightConfig, LightGroup, ShadowWallConfig, SidePanelConfig, TubeConfig } from '../types';
-import { saveModel as dbSaveModel, getModel as dbGetModel, deleteModel as dbDeleteModel } from './storageApi';
+import type { AppConfig, DisplayConfig, LightConfig, LightGroup, ShadowWallConfig, SidePanelConfig, TubeConfig, ZoneConfig } from '../types';
+import { saveModel as dbSaveModel, getModel as dbGetModel, deleteAllModels } from './storageApi';
 import { getSettings, setAllSettings, type AppSettings } from './settingsStore';
 import { isSimulationActive } from '../contexts/SimulationModeContext';
 
 const CONFIG_KEY = 'config';
+
+/**
+ * Hook invoked after every persisted config mutation. Wired to
+ * haSync.schedulePush by the Dashboard (kept as an injection point
+ * to avoid a configApi ↔ haSync import cycle).
+ */
+let configChangedHook: ((config: AppConfig) => void) | null = null;
+export function setConfigChangedHook(fn: ((config: AppConfig) => void) | null): void {
+  configChangedHook = fn;
+}
 
 const DEFAULT_CONFIG: AppConfig = {
   location: { latitude: 43.6077, longitude: 3.8766 },
@@ -50,6 +60,8 @@ export function updateConfig(data: {
   sidePanel?: SidePanelConfig;
   tubes?: TubeConfig[];
   onboarding?: { completed: boolean };
+  zones?: ZoneConfig[];
+  activeZoneId?: string;
 }): void {
   if (isSimulationActive()) {
     // Update in-memory override so the UI reacts, but never persist
@@ -59,8 +71,14 @@ export function updateConfig(data: {
     return;
   }
   const current = getConfig();
-  const merged = { ...current, ...data };
+  const merged: AppConfig = { ...current, ...data, updatedAt: Date.now() };
   localStorage.setItem(CONFIG_KEY, JSON.stringify(merged));
+  configChangedHook?.(merged);
+}
+
+/** Replace the whole config (used when a newer remote config is pulled from HA). */
+export function replaceConfig(config: AppConfig): void {
+  localStorage.setItem(CONFIG_KEY, JSON.stringify(config));
 }
 
 /** Store a GLB model file in IndexedDB. */
@@ -73,10 +91,10 @@ export async function getModelBlob(): Promise<Blob | null> {
   return dbGetModel();
 }
 
-/** Remove config from localStorage and model from IndexedDB. */
+/** Remove config from localStorage and all models from IndexedDB. */
 export async function resetConfig(): Promise<void> {
   localStorage.removeItem(CONFIG_KEY);
-  await dbDeleteModel();
+  await deleteAllModels();
 }
 
 /** Export config + settings + model as a downloadable ZIP. */

--- a/src/services/haSync.ts
+++ b/src/services/haSync.ts
@@ -1,0 +1,175 @@
+/**
+ * Cross-device sync of the 3Dash config and 3D model, using only
+ * HA-native storage (Issue #8) — no external backend, no GitHub tokens.
+ *
+ * Config  → HA frontend user-data store (WebSocket `frontend/set_user_data`
+ *           / `frontend/get_user_data`, key "3dash_config"). Persisted by HA
+ *           in .storage, included in HA backups, scoped per HA user, and works
+ *           on every install type (OS, Supervised, Container, Core).
+ *
+ * Model   → served from HA's `config/www` directory as
+ *           `http(s)://<ha>:<port>/local/3dash/<name>.glb` (unauthenticated,
+ *           correct `model/gltf-binary` MIME, ETag support — verified live).
+ *           The file is cached in IndexedDB and only re-downloaded when the
+ *           ETag changes, so startup stays instant and works offline.
+ *
+ * Conflict resolution: last-writer-wins on AppConfig.updatedAt.
+ */
+
+import type { AppConfig } from '../types';
+import { getActiveHAConnection } from './haWebSocket';
+import { getSetting } from './settingsStore';
+import { saveModel, getModel, saveMeta, getMeta } from './storageApi';
+
+const USER_DATA_KEY = '3dash_config';
+const PUSH_DEBOUNCE_MS = 2500;
+
+export type SyncStatus = 'idle' | 'pushing' | 'pulling' | 'synced' | 'error' | 'offline';
+
+let statusListener: ((s: SyncStatus, detail?: string) => void) | null = null;
+export function setSyncStatusListener(fn: ((s: SyncStatus, detail?: string) => void) | null): void {
+  statusListener = fn;
+}
+function report(s: SyncStatus, detail?: string): void {
+  statusListener?.(s, detail);
+}
+
+/* ── Config sync via frontend user_data ── */
+
+interface RemoteEnvelope {
+  config: AppConfig;
+  updatedAt: number;
+  device: string;
+}
+
+function isSyncEnabled(): boolean {
+  return getSetting('sync').autoSync;
+}
+
+/** Read the remote config envelope from HA. Returns null when none stored. */
+export async function pullRemoteConfig(): Promise<RemoteEnvelope | null> {
+  const ha = getActiveHAConnection();
+  if (!ha?.isConnected) return null;
+  const res = await ha.request({ type: 'frontend/get_user_data', key: USER_DATA_KEY }) as
+    { value?: RemoteEnvelope | null } | null;
+  const env = res?.value ?? null;
+  return env && typeof env.updatedAt === 'number' && env.config ? env : null;
+}
+
+/** Write the given config to HA user data. */
+export async function pushConfigToHA(config: AppConfig): Promise<void> {
+  const ha = getActiveHAConnection();
+  if (!ha?.isConnected) {
+    report('offline');
+    return;
+  }
+  report('pushing');
+  const envelope: RemoteEnvelope = {
+    config,
+    updatedAt: config.updatedAt ?? Date.now(),
+    device: navigator.userAgent.slice(0, 80),
+  };
+  await ha.request({ type: 'frontend/set_user_data', key: USER_DATA_KEY, value: envelope });
+  report('synced');
+}
+
+let pushTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Debounced push — call after every local config mutation. Rapid edits
+ * (e.g. dragging a light) collapse into a single WS write.
+ */
+export function schedulePush(getLatest: () => AppConfig): void {
+  if (!isSyncEnabled()) return;
+  if (pushTimer) clearTimeout(pushTimer);
+  pushTimer = setTimeout(() => {
+    pushTimer = null;
+    pushConfigToHA(getLatest()).catch((e) => {
+      console.warn('[haSync] push failed:', e);
+      report('error', String(e));
+    });
+  }, PUSH_DEBOUNCE_MS);
+}
+
+export interface SyncResult {
+  action: 'pulled' | 'pushed' | 'in-sync' | 'disabled' | 'offline';
+  remoteConfig?: AppConfig;
+}
+
+/**
+ * Reconcile local and remote config after the HA connection comes up.
+ * Newer `updatedAt` wins. Returns the remote config when it superseded
+ * the local one so the caller can apply it and rebuild the scene.
+ */
+export async function syncOnConnect(local: AppConfig): Promise<SyncResult> {
+  if (!isSyncEnabled()) return { action: 'disabled' };
+  const ha = getActiveHAConnection();
+  if (!ha?.isConnected) return { action: 'offline' };
+
+  report('pulling');
+  const remote = await pullRemoteConfig();
+  const localTs = local.updatedAt ?? 0;
+
+  if (!remote || remote.updatedAt < localTs) {
+    // Local is newer (or remote empty) → publish local
+    await pushConfigToHA(local);
+    return { action: 'pushed' };
+  }
+  if (remote.updatedAt === localTs) {
+    report('synced');
+    return { action: 'in-sync' };
+  }
+  // Remote is newer → hand it to the caller
+  report('synced');
+  return { action: 'pulled', remoteConfig: remote.config };
+}
+
+/* ── Model sync via /local/ (config/www) ── */
+
+/** Base URL of the HA instance derived from connection settings. */
+function haHttpBase(): string {
+  const { url, port } = getSetting('connection').haSettings;
+  const proto = window.location.protocol === 'https:' ? 'https' : 'http';
+  return `${url.startsWith('http') ? url : `${proto}://${url}`}:${port}`;
+}
+
+/** Public URL of a model hosted in HA's config/www/3dash directory. */
+export function haModelUrl(name = 'model'): string {
+  return `${haHttpBase()}/local/3dash/${name}.glb`;
+}
+
+/**
+ * Fetch a model from HA's www directory, using the IndexedDB copy as a cache.
+ * HA serves /local/ with a 31-day Cache-Control but honours ETag revalidation,
+ * so we bypass the HTTP cache and do our own conditional fetch.
+ *
+ * Returns the blob, or the cached copy when HA is unreachable (offline-first),
+ * or null when neither exists.
+ */
+export async function fetchModelFromHA(name = 'model'): Promise<Blob | null> {
+  const url = haModelUrl(name);
+  const cacheKey = `ha:${name}`;
+  const cached = await getModel(cacheKey);
+  const cachedEtag = cached ? await getMeta(cacheKey) : null;
+
+  try {
+    const headers: Record<string, string> = {};
+    if (cachedEtag) headers['If-None-Match'] = cachedEtag;
+    const resp = await fetch(url, { headers, cache: 'no-cache' });
+
+    if (resp.status === 304 && cached) return cached;
+    if (!resp.ok) {
+      console.warn(`[haSync] model fetch ${resp.status} for ${url}`);
+      return cached; // fall back to cache (e.g. 404 after file removed)
+    }
+    const blob = await resp.blob();
+    await saveModel(blob, cacheKey);
+    const etag = resp.headers.get('ETag');
+    if (etag) await saveMeta(cacheKey, etag);
+    return blob;
+  } catch (e) {
+    // Network / CORS failure → offline-first fallback
+    console.warn('[haSync] model fetch failed, using cache:', e);
+    return cached;
+  }
+}

--- a/src/services/haSync.ts
+++ b/src/services/haSync.ts
@@ -110,6 +110,18 @@ export async function syncOnConnect(local: AppConfig): Promise<SyncResult> {
   const remote = await pullRemoteConfig();
   const localTs = local.updatedAt ?? 0;
 
+  // Safety net: a device with no content (fresh /connect or new sign-in)
+  // must never overwrite a configured remote, whatever the timestamps say.
+  const localEmpty = !local.lights?.length && !local.displays?.length
+    && !local.tubes?.length && !local.zones?.length;
+  const remoteHasContent = !!(remote && (remote.config.lights?.length
+    || remote.config.displays?.length || remote.config.tubes?.length
+    || remote.config.zones?.length));
+  if (localEmpty && remoteHasContent) {
+    report('synced');
+    return { action: 'pulled', remoteConfig: remote!.config };
+  }
+
   if (!remote || remote.updatedAt < localTs) {
     // Local is newer (or remote empty) → publish local
     await pushConfigToHA(local);

--- a/src/services/settingsStore.ts
+++ b/src/services/settingsStore.ts
@@ -62,6 +62,15 @@ export interface MiscSettings {
   panelRatio: number | null;
 }
 
+export interface SyncSettings {
+  /** Auto-sync config to HA's frontend user-data store (cross-device sync). */
+  autoSync: boolean;
+  /** Where the 3D model is loaded from: this device's IndexedDB, or HA's /local/3dash/. */
+  modelSource: 'device' | 'ha';
+  /** Model file name (without .glb) under config/www/3dash/ when modelSource is 'ha'. */
+  modelName: string;
+}
+
 /* ── Root interface ── */
 
 export interface AppSettings {
@@ -71,6 +80,7 @@ export interface AppSettings {
   environment: EnvironmentSettings;
   controls: ControlsSettings;
   misc: MiscSettings;
+  sync: SyncSettings;
 }
 
 /* ── Section type (for getSetting / updateSettings) ── */
@@ -122,6 +132,11 @@ const DEFAULT_SETTINGS: AppSettings = {
   },
   misc: {
     panelRatio: null,
+  },
+  sync: {
+    autoSync: false,
+    modelSource: 'device',
+    modelName: 'model',
   },
 };
 
@@ -258,6 +273,7 @@ export function getSettings(): AppSettings {
       environment: { ...DEFAULT_SETTINGS.environment, ...parsed.environment },
       controls: { ...DEFAULT_SETTINGS.controls, ...parsed.controls },
       misc: { ...DEFAULT_SETTINGS.misc, ...parsed.misc },
+      sync: { ...DEFAULT_SETTINGS.sync, ...parsed.sync },
     };
   } catch {
     return structuredClone(DEFAULT_SETTINGS);

--- a/src/services/storageApi.ts
+++ b/src/services/storageApi.ts
@@ -1,6 +1,7 @@
 /**
- * IndexedDB helper for storing large assets (GLB model).
- * DB: "appart3d", object store: "assets", key: "model"
+ * IndexedDB helper for storing large assets (GLB models).
+ * DB: "appart3d", object store: "assets".
+ * The main model uses key "model"; per-zone models use their ZoneConfig.modelKey.
  */
 
 const DB_NAME = 'appart3d';
@@ -22,32 +23,67 @@ function openDB(): Promise<IDBDatabase> {
   });
 }
 
-export async function saveModel(blob: Blob): Promise<void> {
+export async function saveModel(blob: Blob, key: string = MODEL_KEY): Promise<void> {
   const db = await openDB();
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readwrite');
-    tx.objectStore(STORE_NAME).put(blob, MODEL_KEY);
+    tx.objectStore(STORE_NAME).put(blob, key);
     tx.oncomplete = () => { db.close(); resolve(); };
     tx.onerror = () => { db.close(); reject(tx.error); };
   });
 }
 
-export async function getModel(): Promise<Blob | null> {
+export async function getModel(key: string = MODEL_KEY): Promise<Blob | null> {
   const db = await openDB();
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readonly');
-    const req = tx.objectStore(STORE_NAME).get(MODEL_KEY);
+    const req = tx.objectStore(STORE_NAME).get(key);
     req.onsuccess = () => { db.close(); resolve(req.result ?? null); };
     req.onerror = () => { db.close(); reject(req.error); };
   });
 }
 
-export async function deleteModel(): Promise<void> {
+export async function deleteModel(key: string = MODEL_KEY): Promise<void> {
   const db = await openDB();
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readwrite');
-    tx.objectStore(STORE_NAME).delete(MODEL_KEY);
+    tx.objectStore(STORE_NAME).delete(key);
     tx.oncomplete = () => { db.close(); resolve(); };
     tx.onerror = () => { db.close(); reject(tx.error); };
+  });
+}
+
+/** Delete every stored asset (used on full reset). */
+export async function deleteAllModels(): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).clear();
+    tx.oncomplete = () => { db.close(); resolve(); };
+    tx.onerror = () => { db.close(); reject(tx.error); };
+  });
+}
+
+/**
+ * Save a small metadata value (e.g. ETag of the last model fetched from HA)
+ * alongside the assets. Stored under "meta:<key>".
+ */
+export async function saveMeta(key: string, value: string): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(value, `meta:${key}`);
+    tx.oncomplete = () => { db.close(); resolve(); };
+    tx.onerror = () => { db.close(); reject(tx.error); };
+  });
+}
+
+export async function getMeta(key: string): Promise<string | null> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).get(`meta:${key}`);
+    req.onsuccess = () => { db.close(); resolve(typeof req.result === 'string' ? req.result : null); };
+    req.onerror = () => { db.close(); reject(req.error); };
   });
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,8 @@ export interface LightConfig {
   modeEntityId?: string;
   /** Secondary entity ID to toggle on double-tap (e.g., a fan entity attached to a ceiling light). */
   doubleTapEntityId?: string;
+  /** Hide the bulb mesh entirely — the light stays clickable and still illuminates the room. */
+  hidden?: boolean;
 }
 
 export interface LightGroup {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -142,6 +142,44 @@ export interface OnboardingState {
   completed: boolean;
 }
 
+// --- Zones / Floors ---
+
+/**
+ * Controls which meshes of the loaded model are visible while a zone is active.
+ * Matching is done against mesh (node) names exported from the modeling tool,
+ * e.g. prefix "GF_" for all ground-floor meshes.
+ */
+export interface ZoneMeshFilter {
+  mode: 'include' | 'exclude';
+  /** Mesh-name prefixes (case-insensitive). */
+  prefixes: string[];
+}
+
+/** Camera pose to fly to when a zone is activated. */
+export interface ZoneCameraPose {
+  alpha: number;
+  beta: number;
+  radius: number;
+  target: { x: number; y: number; z: number };
+}
+
+export interface ZoneConfig {
+  id: string;
+  name: string;
+  /** Lucide icon name shown in the zone switcher (e.g. "Home", "Car", "Trees"). */
+  icon?: string;
+  /**
+   * Separate model for this zone, stored in IndexedDB under this key
+   * (and optionally mirrored to HA at /local/3dash/<modelKey>.glb).
+   * When undefined, the zone uses the main model with `meshFilter` applied.
+   */
+  modelKey?: string;
+  /** Visibility filter applied to the main model when this zone is active. */
+  meshFilter?: ZoneMeshFilter;
+  /** Optional camera pose to animate to when switching to this zone. */
+  cameraPose?: ZoneCameraPose | null;
+}
+
 export interface AppConfig {
   location: {
     latitude: number;
@@ -156,6 +194,12 @@ export interface AppConfig {
   sidePanel?: SidePanelConfig;
   tubes?: TubeConfig[];
   onboarding?: OnboardingState;
+  /** Multi-floor / area definitions. Empty or undefined = single-zone mode. */
+  zones?: ZoneConfig[];
+  /** Currently selected zone (persists across sessions/devices). */
+  activeZoneId?: string;
+  /** Last-modified timestamp (ms epoch) used for cross-device sync conflict resolution. */
+  updatedAt?: number;
 }
 
 export interface HASettings {

--- a/src/utils/validateGlb.ts
+++ b/src/utils/validateGlb.ts
@@ -1,0 +1,73 @@
+/**
+ * Structural validation of a GLB (binary glTF) file before it is accepted.
+ * Checks the 12-byte header and the chunk layout without parsing the scene,
+ * so it is fast even for large files.
+ *
+ * GLB layout (glTF 2.0 spec):
+ *   uint32 magic   = 0x46546C67 ("glTF")
+ *   uint32 version = 2
+ *   uint32 length  = total file size in bytes
+ *   then one or more chunks: uint32 chunkLength, uint32 chunkType, data
+ *   first chunk must be JSON (0x4E4F534A "JSON")
+ */
+
+export interface GlbValidationResult {
+  valid: boolean;
+  error?: string;
+  /** Parsed asset info when available (generator, version). */
+  generator?: string;
+  /** Number of meshes declared in the JSON chunk. */
+  meshCount?: number;
+}
+
+const GLB_MAGIC = 0x46546c67; // "glTF"
+const CHUNK_JSON = 0x4e4f534a; // "JSON"
+
+export async function validateGlb(file: Blob): Promise<GlbValidationResult> {
+  if (file.size < 20) {
+    return { valid: false, error: 'File is too small to be a GLB model.' };
+  }
+
+  // Header + first chunk header (20 bytes)
+  const head = new DataView(await file.slice(0, 20).arrayBuffer());
+
+  if (head.getUint32(0, true) !== GLB_MAGIC) {
+    return { valid: false, error: 'Not a binary glTF file (missing "glTF" magic). Export as .glb, not .gltf.' };
+  }
+  const version = head.getUint32(4, true);
+  if (version !== 2) {
+    return { valid: false, error: `Unsupported glTF version ${version} (expected 2).` };
+  }
+  const declaredLength = head.getUint32(8, true);
+  if (declaredLength > file.size) {
+    return { valid: false, error: 'File is truncated (declared length exceeds actual size).' };
+  }
+
+  const jsonChunkLength = head.getUint32(12, true);
+  if (head.getUint32(16, true) !== CHUNK_JSON) {
+    return { valid: false, error: 'Malformed GLB: first chunk is not JSON.' };
+  }
+  if (20 + jsonChunkLength > file.size) {
+    return { valid: false, error: 'Malformed GLB: JSON chunk extends past end of file.' };
+  }
+
+  // Parse the JSON chunk for basic sanity + useful info
+  try {
+    const jsonText = await file.slice(20, 20 + jsonChunkLength).text();
+    const gltf = JSON.parse(jsonText) as {
+      asset?: { generator?: string; version?: string };
+      meshes?: unknown[];
+      scenes?: unknown[];
+    };
+    if (!gltf.asset?.version) {
+      return { valid: false, error: 'Malformed GLB: missing asset descriptor.' };
+    }
+    const meshCount = gltf.meshes?.length ?? 0;
+    if (meshCount === 0) {
+      return { valid: false, error: 'The model contains no meshes — nothing to display.' };
+    }
+    return { valid: true, generator: gltf.asset.generator, meshCount };
+  } catch {
+    return { valid: false, error: 'Malformed GLB: JSON chunk is not valid JSON.' };
+  }
+}


### PR DESCRIPTION
## Summary

This PR resolves #8 with a fully HA-native storage design — no external backend, no cloud, no GitHub tokens — and adds a multi-floor/zone system plus upload validation.

### Cross-device sync (#8)
- **Config JSON** syncs through HA's frontend user-data store (WebSocket `frontend/set_user_data` / `get_user_data`, key `3dash_config`). Works on every HA install type, is per-user, authenticated, included in HA backups, and rides the WebSocket connection the app already holds — so no CORS setup is needed.
- **3D model** can be served from `config/www/3dash/<name>.glb` (`/local/` path). Verified live: correct `model/gltf-binary` MIME and ETag support. The app caches the model in IndexedDB and revalidates with `If-None-Match`, so startup is instant and works offline.
- Conflict resolution: last-writer-wins on a new `AppConfig.updatedAt` stamp; local edits auto-push (debounced), newer remote configs are pulled and applied on connect.
- The Media Source API was evaluated and ruled out: upload and serving both reject non image/video/audio MIME types (details in `docs/ha-sync.md`).

### Multi-floor / zones
- New `ZoneConfig` schema: zones show/hide model meshes by name prefix (single model, instant toggling, no reload) and can store a camera pose per zone.
- Floating action button on the dashboard to switch between zones; zone editor under Settings → Zones (with camera-view capture). Active zone persists in the config and syncs across devices.

### Upload UX
- Structural GLB validation before accepting a file (magic bytes, glTF version, chunk layout, mesh count) with clear error messages.
- Lightweight toast notification system for success/error/warning feedback.

### Docs
- `docs/ha-sync.md` documents the architecture, the live test results against a real HA instance, and the required `cors_allowed_origins` setting when the webapp is served from a different origin than HA.

## Test plan
- `tsc --noEmit` and `vite build` pass.
- Smoke-tested in the browser: onboarding renders with the new validation step, simulation mode shows the zone FAB, zone selection flies the camera to the stored pose.
- Config user-data round-trip and `/local/` model serving verified against a live HA 2026.x instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)